### PR TITLE
Gas optimization in NFT raffler

### DIFF
--- a/packages/contracts/sources/nft-raffle/struct/utils.func
+++ b/packages/contracts/sources/nft-raffle/struct/utils.func
@@ -1,3 +1,10 @@
+;; Constant slices heavily used as dictionary values
+;; Inlined to avoid cell creation fee.
+slice const_1bit_0() asm "b{0} PUSHSLICE";
+slice const_1bit_1() asm "b{1} PUSHSLICE";
+slice const_4bit_2() asm "x{2} PUSHSLICE";
+slice const_4bit_3() asm "x{3} PUSHSLICE";
+
 () utils::send_nft(int mode, int amount, slice to, int nft_addr) impure inline_ref {
     builder body = begin_cell()
         .store_uint(op::transfer(), 32) ;; op
@@ -56,10 +63,10 @@
         return (dict, 0, 0);
     }
     if (data~load_uint(4) == 0) {
-        dict~udict_set(256, nft_addr, begin_cell().store_uint(2, 4).end_cell().begin_parse());
+        dict~udict_set(256, nft_addr, const_4bit_2());
         left_success = -1;
     } else {
-        dict~udict_set(256, nft_addr, begin_cell().store_uint(3, 4).end_cell().begin_parse());
+        dict~udict_set(256, nft_addr, const_4bit_3());
         right_success = -1;
     }
     return(dict, left_success, right_success);
@@ -71,9 +78,9 @@ cell utils::raffle_nfts(cell raffled_nfts, cell nfts) inline_ref {
         (key, slice data, int found) = nfts.udict_get_next?(256, key);
         if (found) {
             if (rand(2) == 0) {
-                raffled_nfts~udict_set(256, key, begin_cell().store_uint(1, 1).end_cell().begin_parse());
+                raffled_nfts~udict_set(256, key, const_1bit_1());
             } else {
-                raffled_nfts~udict_set(256, key, begin_cell().store_uint(0, 1).end_cell().begin_parse());
+                raffled_nfts~udict_set(256, key, const_1bit_0());
             }
         }
     } until (~ found)

--- a/packages/contracts/sources/nft-swap.fc
+++ b/packages/contracts/sources/nft-swap.fc
@@ -15,6 +15,8 @@ int nft_send_amount() asm "50000000 PUSHINT"; ;; 0.05 TON
 int min_tons_per_nft() asm "100000000 PUSHINT"; ;; 0.1 TON
 int min_tons_for_storage_after_swap() asm "1000000 PUSHINT"; ;; 0.001 TON
 
+slice const_1bit_1() asm "b{1} PUSHSLICE";
+
 global int state;
 global slice supervisor;
 global slice commission_gainer;
@@ -72,7 +74,7 @@ global int right_coins_got;
         return (dict, 0);
     }
 
-    dict~udict_set(256, nft, begin_cell().store_uint(1,1).end_cell().begin_parse());
+    dict~udict_set(256, nft, const_1bit_1());
     return (dict, -1);
 }
 


### PR DESCRIPTION
Creating cell and parsing it takes at least 600 gas units, so it's better to avoid it where cell data is constant.